### PR TITLE
keep the session longer on mobile

### DIFF
--- a/src/utils/server.ts
+++ b/src/utils/server.ts
@@ -22,7 +22,6 @@ export const SESSION_CONFIG = {
   cookieName: "Devcon App",
   password: SERVER_CONFIG.SESSION_SECRET,
   cookieOptions: {
-    maxAge: undefined,
     secure: process.env.NODE_ENV === "production",
   }
 }


### PR DESCRIPTION
Session cookie is a way to keep security. But it might make a bad user experience on the mobile or PWA.
When you switch to use different apps and switch back to the mobile safari or PWA, your session has been terminated.
So you always need to login again.
Removing the maxAge settings can make the cookie existing longer until 2 weeks.
For a better user experience, we can add the remember me checkbox in the future.
